### PR TITLE
Removes active record dependencies

### DIFF
--- a/deleted_at.gemspec
+++ b/deleted_at.gemspec
@@ -30,10 +30,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  rails_versions = ['>= 4.1', '< 5']
+  rails_versions = ['>= 4.1', '< 6']
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_runtime_dependency 'pg', '~> 0'
+  spec.add_runtime_dependency 'pg'
   spec.add_runtime_dependency "activerecord", rails_versions
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/lib/deleted_at/views.rb
+++ b/lib/deleted_at/views.rb
@@ -23,23 +23,23 @@ module DeletedAt
     end
 
     def self.all_table_exists?(model)
-      query = model.connection.execute <<-SQL
+      query = model.connection.select_value <<-SQL
         SELECT EXISTS (
           SELECT 1
           FROM   information_schema.tables
           WHERE  table_name = '#{all_table(model)}'
-        );
+        ) as exists;
       SQL
       get_truthy_value_from_psql(query)
     end
 
     def self.deleted_view_exists?(model)
-      query = model.connection.execute <<-SQL
+      query = model.connection.select_value <<-SQL
         SELECT EXISTS (
           SELECT 1
           FROM   information_schema.tables
           WHERE  table_name = '#{deleted_view(model)}'
-        );
+        ) as exists;
       SQL
       get_truthy_value_from_psql(query)
     end
@@ -72,10 +72,7 @@ module DeletedAt
     private
 
     def self.get_truthy_value_from_psql(result)
-      # Some versions of PSQL return {"?column?"=>"t"}
-      # instead of {"first"=>"t"}, so we're saying screw it,
-      # just give me the first value of whatever is returned
-      result.try(:first).try(:values).try(:first) == 't'
+      ['t', true].include?(result)
     end
 
   end


### PR DESCRIPTION
In order to utilize deleted_at with Rails 5+ we need to remove the
contraints around active record. This led to a mismatch with the way
deleted at was querying postgres to know if tables were installed. The
select statements were altered to make a cleaner predicate method in
determining if the views had been installed or not.